### PR TITLE
DocumentDB CollectionID

### DIFF
--- a/SharpRepository.AzureDocumentDb/DocumentDbRepository.cs
+++ b/SharpRepository.AzureDocumentDb/DocumentDbRepository.cs
@@ -5,8 +5,8 @@ namespace SharpRepository.AzureDocumentDb
 {
     public class DocumentDbRepository<T, TKey> : DocumentDbRepositoryBase<T, TKey> where T : class, new()
     {
-        public DocumentDbRepository(string endpointUrl, string authorizationKey, string databaseId, bool createIfNotExists, ICachingStrategy<T, TKey> cachingStrategy = null)
-            : base(endpointUrl, authorizationKey, databaseId, createIfNotExists, cachingStrategy)
+        public DocumentDbRepository(string endpointUrl, string authorizationKey, string databaseId, bool createIfNotExists, string collectionId = null, ICachingStrategy<T, TKey> cachingStrategy = null)
+            : base(endpointUrl, authorizationKey, databaseId, createIfNotExists, collectionId, cachingStrategy)
         {
         }
     }

--- a/SharpRepository.AzureDocumentDb/DocumentDbRepositoryConfiguration.cs
+++ b/SharpRepository.AzureDocumentDb/DocumentDbRepositoryConfiguration.cs
@@ -4,11 +4,12 @@ namespace SharpRepository.AzureDocumentDb
 {
     public class DocumentDbRepositoryConfiguration : RepositoryConfiguration
     {
-        public DocumentDbRepositoryConfiguration(string endpointUrl, string authorizationKey, string databaseId, bool createIfNotExists = false, string cachingStrategy = null, string cachingProvider = null)
+        public DocumentDbRepositoryConfiguration(string endpointUrl, string authorizationKey, string databaseId, string collectionId = null, bool createIfNotExists = false, string cachingStrategy = null, string cachingProvider = null)
         {
             EndpointUrl = endpointUrl;
             AuthorizationKey = authorizationKey;
             DatabaseId = databaseId;
+            CollectionId = collectionId;
             CreateIfNotExists = createIfNotExists;
 
             CachingProvider = cachingProvider;
@@ -29,6 +30,11 @@ namespace SharpRepository.AzureDocumentDb
         public string DatabaseId
         {
             set { Attributes["databaseId"] = value; }
+        }
+
+        public string CollectionId
+        {
+            set { Attributes["collectionId"] = value; }
         }
 
         public bool CreateIfNotExists

--- a/SharpRepository.CouchDbRepository/packages.config
+++ b/SharpRepository.CouchDbRepository/packages.config
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="4.5.10" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40" />
-  <package id="Remotion.Linq" version="1.13.171" targetFramework="net40" />
   <package id="Remotion.Linq" version="1.13.183.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
This PR makes it possible to set a custom CollectionID for each DocumentDbRepository. I needed this when testing the current implementation.

If collectionId parameter is not passed, it is still generated the same way as before.

Here's a code sample where the new collectionId parameter is set:

``` C#
public class BlogPostDocDbRepository : DocumentDbRepository<BlogPost, string>, IBlogPostRepository
    {
        public BlogPostDocDbRepository(RepositoryConfiguration config)
            : base(config.EndpointUrl, config.AuthorizationKey, config.DatabaseId, config.CreateIfNotExists, "BlogPosts")
        { }
    }
```
